### PR TITLE
Added Scheme stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,19 @@ The majority of the Docker images in this repo are available on https://hub.dock
 | Stack                                                    | Docker Repository                                                                     | Notes                                          |
 |----------------------------------------------------------|---------------------------------------------------------------------------------------|------------------------------------------------|
 | **[Ada](https://www.gnu.org/software/gnat/)**            | [rawpair/ada](https://hub.docker.com/repository/docker/rawpair/ada)                   | Includes GNU GNAT                              |
+| **[Chicken Scheme](https://www.call-cc.org/)**           | [rawpair/chicken-scheme](https://hub.docker.com/repository/docker/rawpair/chicken-scheme) |                                            |
 | **[Clojure](https://clojure.org/)**                      | [rawpair/clojure](https://hub.docker.com/repository/docker/rawpair/clojure)           | Runs on Temurin (OpenJDK)                      |
 | **[COBOL](https://gnucobol.sourceforge.io/)**            | [rawpair/gnucobol](https://hub.docker.com/repository/docker/rawpair/gnucobol)         | Includes GNU COBOL                             |
 | **[Elixir](https://elixir-lang.org/)**                   | [rawpair/elixir](https://hub.docker.com/repository/docker/rawpair/elixir)             |                                                |
+| **[Gambit Scheme](https://gambitscheme.org/)**           | [rawpair/gambit-scheme](https://hub.docker.com/repository/docker/rawpair/gambit-scheme) |                                             |
+| **[Guile](https://www.gnu.org/software/guile/)**         | [rawpair/gnuguile](https://hub.docker.com/repository/docker/rawpair/gnuguile)         |                                                |
 | **[Haskell](https://www.haskell.org/)**                  | [rawpair/haskell](https://hub.docker.com/repository/docker/rawpair/haskell)           | Includes GHC                                   |
 | **[Janet](https://janet-lang.org/)**                     | [rawpair/janet](https://hub.docker.com/repository/docker/rawpair/janet)               |                                                |
 | **[Julia](https://julialang.org/)**                      | [rawpair/julia](https://hub.docker.com/repository/docker/rawpair/julia)               |                                                |
 | **[.NET](https://dotnet.microsoft.com/)**                | [rawpair/dotnet](https://hub.docker.com/repository/docker/rawpair/dotnet)             | Includes C#, F#, VB.NET, Mono                  |
 | **[Liberty Eiffel](https://www.liberty-eiffel.org/)**    | [rawpair/liberty-eiffel](https://hub.docker.com/repository/docker/rawpair/liberty-eiffel) | Compiled from [source](https://github.com/LibertyEiffel/Liberty) |
 | **[Metasploit](https://www.metasploit.com/)**            | [rawpair/metasploit](https://hub.docker.com/repository/docker/rawpair/metasploit)     | Metasploit Framework                           |
+| **[MIT/GNU Scheme](https://www.gnu.org/software/mit-gnu-scheme/)** | [rawpair/mit-gnu-scheme](https://hub.docker.com/repository/docker/rawpair/mit-gnu-scheme) |                                  |
 | **[Nim](https://nim-lang.org/)**                         | [rawpair/nim](https://hub.docker.com/repository/docker/rawpair/nim)                   | Includes nimble                                |
 | **[Node.js](https://nodejs.org/)**                       | [rawpair/node](https://hub.docker.com/repository/docker/rawpair/node)                 | Managed via NVM                                |
 | **[OCaml](https://ocaml.org/)**                          | [rawpair/ocaml](https://hub.docker.com/repository/docker/rawpair/ocaml)               | Includes OPAM, OCaml 4.14.1, Dune, Menhir      |
@@ -121,6 +125,16 @@ Inspect:
 
 `docker buildx build --platform linux/amd64,linux/arm64 -t rawpair/ada:trixie -f ./ada/trixie/Dockerfile --push .`
 
+#### Chicken Scheme
+
+##### Debian Bookworm
+
+`docker buildx build --platform linux/amd64,linux/arm64 -t rawpair/chicken-scheme:bookworm -f ./chicken-scheme/bookworm/Dockerfile --push .`
+
+##### Debian Trixie
+
+`docker buildx build --platform linux/amd64,linux/arm64 -t rawpair/chicken-scheme:trixie -f ./chicken-scheme/trixie/Dockerfile --push .`
+
 #### Clojure
 
 ##### Temurin 21 - Debian Bookworm
@@ -143,6 +157,16 @@ Inspect:
 
 `docker buildx build --platform linux/amd64,linux/arm64 -t rawpair/elixir:bookworm -f ./elixir/bookworm/Dockerfile --push .`
 
+#### Gambit Scheme
+
+##### Debian Bookworm
+
+`docker buildx build --platform linux/amd64,linux/arm64 -t rawpair/gambit-scheme:bookworm -f ./gambit-scheme/bookworm/Dockerfile --push .`
+
+##### Debian Trixie
+
+`docker buildx build --platform linux/amd64,linux/arm64 -t rawpair/gambit-scheme:trixie -f ./gambit-scheme/trixie/Dockerfile --push .`
+
 #### GNU COBOL
 
 ##### Debian Bookworm
@@ -152,6 +176,16 @@ Inspect:
 ##### Debian Trixie
 
 `docker buildx build --platform linux/amd64,linux/arm64 -t rawpair/gnucobol:trixie -f ./gnucobol/trixie/Dockerfile --push .`
+
+#### GNU Guile
+
+##### Debian Bookworm
+
+`docker buildx build --platform linux/amd64,linux/arm64 -t rawpair/gnuguile:bookworm -f ./gnuguile/bookworm/Dockerfile --push .`
+
+##### Debian Trixie
+
+`docker buildx build --platform linux/amd64,linux/arm64 -t rawpair/gnuguile:trixie -f ./gnuguile/trixie/Dockerfile --push .`
 
 #### GNU Smalltalk - Ubuntu 24.04
 
@@ -176,6 +210,12 @@ Inspect:
 #### Metasploit Framework - 6.4.0
 
 `docker buildx build --platform linux/amd64,linux/arm64 -t rawpair/metasploit:6.4.0 -f ./metasploit/6.4.0/Dockerfile --push .`
+
+#### MIT/GNU Scheme
+
+##### Debian Bookworm
+
+`docker buildx build --platform linux/amd64 -t rawpair/mit-gnu-scheme:bookworm -f ./mit-gnu-scheme/bookworm/Dockerfile --push .`
 
 #### Nim - Debian Trixie
 

--- a/stacks/chicken-scheme/bookworm/Dockerfile
+++ b/stacks/chicken-scheme/bookworm/Dockerfile
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: MPL-2.0
 
-FROM ubuntu:24.04
+FROM debian:bookworm-slim
 
 # Base setup
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    chicken-bin \
+    make \
     bash \
     curl \
     libjson-c5 \
-    libwebsockets19t64 \
+    libwebsockets17 \
     ca-certificates \
     libssl3 \
-    pkg-config \
     procps \
     tmux \
     vim \
@@ -19,23 +20,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     file \
     supervisor \
-    libsigsegv-dev \
-    libtool \
-    gawk \
-    libsigsegv2 \
-    bison \
-    flex \
-    texinfo \
-    zip \
-    unzip \
-    libffi-dev \
-    autoconf \
-    automake \
-    libltdl-dev \
-    make \
-    libc-bin \
-    locales \
-    libiconv-hook-dev \
+    gcc \
+    g++ \
+    xz-utils \
+    libc6-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install ttyd (arch-aware)
@@ -54,26 +42,6 @@ RUN set -eux; \
 
 # Install Vector
 RUN curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y --prefix /usr/local
-
-WORKDIR /usr/src
-
-RUN git clone https://git.savannah.gnu.org/git/smalltalk.git
-
-WORKDIR /usr/src/smalltalk
-
-RUN autoreconf --install --force
-RUN ./configure --prefix=/opt/smalltalk
-# Serialize make step as it tends to fail on arm64 otherwise
-RUN make -j1
-RUN make install
-
-ENV PATH="/opt/smalltalk/bin:$PATH"
-
-WORKDIR /usr/src
-
-RUN git clone https://github.com/timfel/JSON-st
-
-RUN gst-package JSON-st/package.xml
 
 # Create dev user and working directory
 RUN useradd -ms /bin/bash devuser

--- a/stacks/chicken-scheme/trixie/Dockerfile
+++ b/stacks/chicken-scheme/trixie/Dockerfile
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: MPL-2.0
 
-FROM ubuntu:24.04
+FROM debian:trixie-slim
 
 # Base setup
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    chicken-bin \
+    make \
     bash \
     curl \
     libjson-c5 \
     libwebsockets19t64 \
     ca-certificates \
     libssl3 \
-    pkg-config \
     procps \
     tmux \
     vim \
@@ -19,23 +20,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     file \
     supervisor \
-    libsigsegv-dev \
-    libtool \
-    gawk \
-    libsigsegv2 \
-    bison \
-    flex \
-    texinfo \
-    zip \
-    unzip \
-    libffi-dev \
-    autoconf \
-    automake \
-    libltdl-dev \
-    make \
-    libc-bin \
-    locales \
-    libiconv-hook-dev \
+    gcc \
+    g++ \
+    xz-utils \
+    libc6-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install ttyd (arch-aware)
@@ -54,26 +42,6 @@ RUN set -eux; \
 
 # Install Vector
 RUN curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y --prefix /usr/local
-
-WORKDIR /usr/src
-
-RUN git clone https://git.savannah.gnu.org/git/smalltalk.git
-
-WORKDIR /usr/src/smalltalk
-
-RUN autoreconf --install --force
-RUN ./configure --prefix=/opt/smalltalk
-# Serialize make step as it tends to fail on arm64 otherwise
-RUN make -j1
-RUN make install
-
-ENV PATH="/opt/smalltalk/bin:$PATH"
-
-WORKDIR /usr/src
-
-RUN git clone https://github.com/timfel/JSON-st
-
-RUN gst-package JSON-st/package.xml
 
 # Create dev user and working directory
 RUN useradd -ms /bin/bash devuser

--- a/stacks/gambit-scheme/bookworm/Dockerfile
+++ b/stacks/gambit-scheme/bookworm/Dockerfile
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: MPL-2.0
 
-FROM ubuntu:24.04
+FROM debian:bookworm-slim
 
 # Base setup
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    gambc \
+    make \
     bash \
     curl \
     libjson-c5 \
-    libwebsockets19t64 \
+    libwebsockets17 \
     ca-certificates \
     libssl3 \
-    pkg-config \
     procps \
     tmux \
     vim \
@@ -19,23 +20,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     file \
     supervisor \
-    libsigsegv-dev \
-    libtool \
-    gawk \
-    libsigsegv2 \
-    bison \
-    flex \
-    texinfo \
-    zip \
-    unzip \
-    libffi-dev \
-    autoconf \
-    automake \
-    libltdl-dev \
-    make \
-    libc-bin \
-    locales \
-    libiconv-hook-dev \
+    gcc \
+    g++ \
+    xz-utils \
+    libc6-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install ttyd (arch-aware)
@@ -54,26 +42,6 @@ RUN set -eux; \
 
 # Install Vector
 RUN curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y --prefix /usr/local
-
-WORKDIR /usr/src
-
-RUN git clone https://git.savannah.gnu.org/git/smalltalk.git
-
-WORKDIR /usr/src/smalltalk
-
-RUN autoreconf --install --force
-RUN ./configure --prefix=/opt/smalltalk
-# Serialize make step as it tends to fail on arm64 otherwise
-RUN make -j1
-RUN make install
-
-ENV PATH="/opt/smalltalk/bin:$PATH"
-
-WORKDIR /usr/src
-
-RUN git clone https://github.com/timfel/JSON-st
-
-RUN gst-package JSON-st/package.xml
 
 # Create dev user and working directory
 RUN useradd -ms /bin/bash devuser

--- a/stacks/gambit-scheme/trixie/Dockerfile
+++ b/stacks/gambit-scheme/trixie/Dockerfile
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: MPL-2.0
 
-FROM ubuntu:24.04
+FROM debian:trixie-slim
 
 # Base setup
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    gambc \
+    make \
     bash \
     curl \
     libjson-c5 \
     libwebsockets19t64 \
     ca-certificates \
     libssl3 \
-    pkg-config \
     procps \
     tmux \
     vim \
@@ -19,23 +20,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     file \
     supervisor \
-    libsigsegv-dev \
-    libtool \
-    gawk \
-    libsigsegv2 \
-    bison \
-    flex \
-    texinfo \
-    zip \
-    unzip \
-    libffi-dev \
-    autoconf \
-    automake \
-    libltdl-dev \
-    make \
-    libc-bin \
-    locales \
-    libiconv-hook-dev \
+    gcc \
+    g++ \
+    xz-utils \
+    libc6-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install ttyd (arch-aware)
@@ -54,26 +42,6 @@ RUN set -eux; \
 
 # Install Vector
 RUN curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y --prefix /usr/local
-
-WORKDIR /usr/src
-
-RUN git clone https://git.savannah.gnu.org/git/smalltalk.git
-
-WORKDIR /usr/src/smalltalk
-
-RUN autoreconf --install --force
-RUN ./configure --prefix=/opt/smalltalk
-# Serialize make step as it tends to fail on arm64 otherwise
-RUN make -j1
-RUN make install
-
-ENV PATH="/opt/smalltalk/bin:$PATH"
-
-WORKDIR /usr/src
-
-RUN git clone https://github.com/timfel/JSON-st
-
-RUN gst-package JSON-st/package.xml
 
 # Create dev user and working directory
 RUN useradd -ms /bin/bash devuser

--- a/stacks/gnuguile/bookworm/Dockerfile
+++ b/stacks/gnuguile/bookworm/Dockerfile
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: MPL-2.0
 
-FROM ubuntu:24.04
+FROM debian:bookworm-slim
 
 # Base setup
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    guile-3.0 \
     bash \
     curl \
     libjson-c5 \
-    libwebsockets19t64 \
+    libwebsockets17 \
     ca-certificates \
     libssl3 \
-    pkg-config \
     procps \
     tmux \
     vim \
@@ -19,23 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     file \
     supervisor \
-    libsigsegv-dev \
-    libtool \
-    gawk \
-    libsigsegv2 \
-    bison \
-    flex \
-    texinfo \
-    zip \
-    unzip \
-    libffi-dev \
-    autoconf \
-    automake \
-    libltdl-dev \
-    make \
-    libc-bin \
-    locales \
-    libiconv-hook-dev \
+    xz-utils \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install ttyd (arch-aware)
@@ -54,26 +38,6 @@ RUN set -eux; \
 
 # Install Vector
 RUN curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y --prefix /usr/local
-
-WORKDIR /usr/src
-
-RUN git clone https://git.savannah.gnu.org/git/smalltalk.git
-
-WORKDIR /usr/src/smalltalk
-
-RUN autoreconf --install --force
-RUN ./configure --prefix=/opt/smalltalk
-# Serialize make step as it tends to fail on arm64 otherwise
-RUN make -j1
-RUN make install
-
-ENV PATH="/opt/smalltalk/bin:$PATH"
-
-WORKDIR /usr/src
-
-RUN git clone https://github.com/timfel/JSON-st
-
-RUN gst-package JSON-st/package.xml
 
 # Create dev user and working directory
 RUN useradd -ms /bin/bash devuser

--- a/stacks/gnuguile/trixie/Dockerfile
+++ b/stacks/gnuguile/trixie/Dockerfile
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: MPL-2.0
 
-FROM ubuntu:24.04
+FROM debian:trixie-slim
 
 # Base setup
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    guile-3.0 \
+    make \
     bash \
     curl \
     libjson-c5 \
     libwebsockets19t64 \
     ca-certificates \
     libssl3 \
-    pkg-config \
     procps \
     tmux \
     vim \
@@ -19,23 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     file \
     supervisor \
-    libsigsegv-dev \
-    libtool \
-    gawk \
-    libsigsegv2 \
-    bison \
-    flex \
-    texinfo \
-    zip \
-    unzip \
-    libffi-dev \
-    autoconf \
-    automake \
-    libltdl-dev \
-    make \
-    libc-bin \
-    locales \
-    libiconv-hook-dev \
+    xz-utils \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install ttyd (arch-aware)
@@ -54,26 +39,6 @@ RUN set -eux; \
 
 # Install Vector
 RUN curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y --prefix /usr/local
-
-WORKDIR /usr/src
-
-RUN git clone https://git.savannah.gnu.org/git/smalltalk.git
-
-WORKDIR /usr/src/smalltalk
-
-RUN autoreconf --install --force
-RUN ./configure --prefix=/opt/smalltalk
-# Serialize make step as it tends to fail on arm64 otherwise
-RUN make -j1
-RUN make install
-
-ENV PATH="/opt/smalltalk/bin:$PATH"
-
-WORKDIR /usr/src
-
-RUN git clone https://github.com/timfel/JSON-st
-
-RUN gst-package JSON-st/package.xml
 
 # Create dev user and working directory
 RUN useradd -ms /bin/bash devuser

--- a/stacks/mit-gnu-scheme/bookworm/Dockerfile
+++ b/stacks/mit-gnu-scheme/bookworm/Dockerfile
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: MPL-2.0
 
-FROM ubuntu:24.04
+FROM debian:bookworm-slim
 
 # Base setup
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    mit-scheme \
+    make \
     bash \
     curl \
     libjson-c5 \
-    libwebsockets19t64 \
+    libwebsockets17 \
     ca-certificates \
     libssl3 \
-    pkg-config \
     procps \
     tmux \
     vim \
@@ -19,23 +20,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     file \
     supervisor \
-    libsigsegv-dev \
-    libtool \
-    gawk \
-    libsigsegv2 \
-    bison \
-    flex \
-    texinfo \
-    zip \
-    unzip \
-    libffi-dev \
-    autoconf \
-    automake \
-    libltdl-dev \
-    make \
-    libc-bin \
-    locales \
-    libiconv-hook-dev \
+    gcc \
+    g++ \
+    xz-utils \
+    libc6-dev \
+    libncurses-dev \
+    libncurses6 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install ttyd (arch-aware)
@@ -54,26 +44,6 @@ RUN set -eux; \
 
 # Install Vector
 RUN curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y --prefix /usr/local
-
-WORKDIR /usr/src
-
-RUN git clone https://git.savannah.gnu.org/git/smalltalk.git
-
-WORKDIR /usr/src/smalltalk
-
-RUN autoreconf --install --force
-RUN ./configure --prefix=/opt/smalltalk
-# Serialize make step as it tends to fail on arm64 otherwise
-RUN make -j1
-RUN make install
-
-ENV PATH="/opt/smalltalk/bin:$PATH"
-
-WORKDIR /usr/src
-
-RUN git clone https://github.com/timfel/JSON-st
-
-RUN gst-package JSON-st/package.xml
 
 # Create dev user and working directory
 RUN useradd -ms /bin/bash devuser

--- a/stacks/stacks.json
+++ b/stacks/stacks.json
@@ -23,6 +23,29 @@
         ]
     },
     {
+        "name": "Chicken Scheme",
+        "tags": [
+            {
+                "id": "chicken-scheme:bookworm",
+                "base": "debian:bookworm-slim",
+                "name": "Chicken Scheme on Debian Bookworm",
+                "platforms": [
+                    "linux/amd64",
+                    "linux/arm64"
+                ]
+            },
+            {
+                "id": "chicken-scheme:trixie",
+                "base": "debian:trixie-slim",
+                "name": "Chicken Schemes on Debian Trixie",
+                "platforms": [
+                    "linux/amd64",
+                    "linux/arm64"
+                ]
+            }
+        ]
+    },
+    {
         "name": "Clojure",
         "tags": [
             {
@@ -99,6 +122,29 @@
         ]
     },
     {
+        "name": "Gambit Scheme",
+        "tags": [
+            {
+                "id": "gambit-scheme:bookworm",
+                "base": "debian:bookworm-slim",
+                "name": "Gambit Scheme on Debian Bookworm",
+                "platforms": [
+                    "linux/amd64",
+                    "linux/arm64"
+                ]
+            },
+            {
+                "id": "gambit-scheme:trixie",
+                "base": "debian:trixie-slim",
+                "name": "Gambit Schemes on Debian Trixie",
+                "platforms": [
+                    "linux/amd64",
+                    "linux/arm64"
+                ]
+            }
+        ]
+    },
+    {
         "name": "GNU COBOL",
         "tags": [
             {
@@ -114,6 +160,29 @@
                 "id": "gnucobol:trixie",
                 "base": "debian:trixie-slim",
                 "name": "GNU COBOL on Debian Trixie",
+                "platforms": [
+                    "linux/amd64",
+                    "linux/arm64"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "GNU Guile",
+        "tags": [
+            {
+                "id": "gnuguile:bookworm",
+                "base": "debian:bookworm-slim",
+                "name": "GNU Guile on Debian Bookworm",
+                "platforms": [
+                    "linux/amd64",
+                    "linux/arm64"
+                ]
+            },
+            {
+                "id": "gnuguile:trixie",
+                "base": "debian:trixie-slim",
+                "name": "GNU Guile on Debian Trixie",
                 "platforms": [
                     "linux/amd64",
                     "linux/arm64"
@@ -201,6 +270,19 @@
                 "platforms": [
                     "linux/amd64",
                     "linux/arm64"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "MIT Scheme",
+        "tags": [
+            {
+                "id": "mitscheme:bookworm",
+                "base": "debian:bookworm-slim",
+                "name": "MIT Scheme on Debian Bookworm",
+                "platforms": [
+                    "linux/amd64"
                 ]
             }
         ]

--- a/stacks/stacks.json
+++ b/stacks/stacks.json
@@ -275,12 +275,12 @@
         ]
     },
     {
-        "name": "MIT Scheme",
+        "name": "MIT/GNU Scheme",
         "tags": [
             {
-                "id": "mitscheme:bookworm",
+                "id": "mit-gnu-scheme:bookworm",
                 "base": "debian:bookworm-slim",
-                "name": "MIT Scheme on Debian Bookworm",
+                "name": "MIT/GNU Scheme on Debian Bookworm",
                 "platforms": [
                     "linux/amd64"
                 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Chicken Scheme, Gambit Scheme, GNU Guile, and MIT/GNU Scheme language stacks with new container images for Debian Bookworm and Trixie variants where applicable.
- **Documentation**
  - Updated documentation to include the new Scheme stacks and detailed multi-architecture build instructions.
- **Chores**
  - Extended configuration to add new stacks and specify supported platforms for each.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->