### PR TITLE
Adding CBQN to stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The majority of the Docker images in this repo are available on https://hub.dock
 | **[Ada](https://www.gnu.org/software/gnat/)**            | [rawpair/ada](https://hub.docker.com/repository/docker/rawpair/ada)                   | Includes GNU GNAT                              |
 | **[Chicken Scheme](https://www.call-cc.org/)**           | [rawpair/chicken-scheme](https://hub.docker.com/repository/docker/rawpair/chicken-scheme) | Includes csi, csc, and chicken-install     |
 | **[Clojure](https://clojure.org/)**                      | [rawpair/clojure](https://hub.docker.com/repository/docker/rawpair/clojure)           | Runs on Temurin (OpenJDK)                      |
+| **[CBQN](https://github.com/dzaima/CBQN/)**              | [rawpair/cbqn](https://hub.docker.com/repository/docker/rawpair/cbqn)                 |                                                |
 | **[COBOL](https://gnucobol.sourceforge.io/)**            | [rawpair/gnucobol](https://hub.docker.com/repository/docker/rawpair/gnucobol)         | Includes GNU COBOL                             |
 | **[Elixir](https://elixir-lang.org/)**                   | [rawpair/elixir](https://hub.docker.com/repository/docker/rawpair/elixir)             | Includes Mix and Hex                           |
 | **[Gambit Scheme](https://gambitscheme.org/)**           | [rawpair/gambit-scheme](https://hub.docker.com/repository/docker/rawpair/gambit-scheme) | Includes gsi and gsc                         |
@@ -167,6 +168,12 @@ Inspect:
 ##### Debian Trixie
 
 `docker buildx build --platform linux/amd64,linux/arm64 -t rawpair/gambit-scheme:trixie -f ./gambit-scheme/trixie/Dockerfile --push .`
+
+#### CBQN
+
+##### Debian Bookworm
+
+`docker buildx build --platform linux/amd64,linux/arm64 -t rawpair/cbqn:bookworm -f ./cbqn/bookworm/Dockerfile --push .`
 
 #### GNU COBOL
 

--- a/stacks/cbqn/bookworm/Dockerfile
+++ b/stacks/cbqn/bookworm/Dockerfile
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: MPL-2.0
 
-FROM debian:trixie-slim
+FROM debian:bookworm-slim
 
 # Base setup
 RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
+    bash \
     curl \
     libjson-c5 \
-    libwebsockets19t64 \
+    libwebsockets17 \
     ca-certificates \
     libssl3 \
     procps \
@@ -18,29 +19,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     file \
     supervisor \
-    gcc \
-    g++ \
-    xz-utils \
-    libc6-dev \
+    locales \
+    libffi-dev \
+    clang \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV NIM_VERSION=2.2.4
-
-WORKDIR /opt/
-
-RUN curl -LO "https://nim-lang.org/download/nim-${NIM_VERSION}.tar.xz"
-RUN tar -xf nim-${NIM_VERSION}.tar.xz
-
-WORKDIR /opt/nim-${NIM_VERSION}
-
-RUN sh build.sh
-RUN bin/nim c koch
-RUN ./koch boot -d:release
-RUN ./koch tools
-
-RUN rm -f ../nim-${NIM_VERSION}.tar.xz
-
-WORKDIR /root
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 
 # Install ttyd (arch-aware)
 RUN set -eux; \
@@ -58,6 +43,16 @@ RUN set -eux; \
 
 # Install Vector
 RUN curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- -y --prefix /usr/local
+
+WORKDIR /opt
+
+RUN git clone https://github.com/dzaima/CBQN.git /opt/cbqn
+
+WORKDIR /opt/cbqn
+
+RUN make o3
+
+ENV PATH="/opt/cbqn:$PATH"
 
 # Create dev user and working directory
 RUN useradd -ms /bin/bash devuser
@@ -100,9 +95,6 @@ ENV TERM=xterm \
     LOG_SESSION_ID=dev-session
 
 USER devuser
-
-ENV PATH="/opt/nim-2.2.4/bin:$PATH"
-
 EXPOSE 7681
 
 CMD ["supervisord", "-c", "/etc/supervisor/conf.d/rawpair.conf"]

--- a/stacks/python-nvidia-cuda/nvidia-ubuntu24.04/Dockerfile
+++ b/stacks/python-nvidia-cuda/nvidia-ubuntu24.04/Dockerfile
@@ -2,9 +2,6 @@
 
 FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
 
-# Non-interactive installation
-ENV DEBIAN_FRONTEND=noninteractive
-
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
@@ -34,12 +31,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN set -eux; \
     ARCH=$(uname -m); \
     case "$ARCH" in \
-        x86_64)   BINARY="ttyd.x86_64" ;; \
-        aarch64)  BINARY="ttyd.aarch64" ;; \
-        armv7l)   BINARY="ttyd.armhf" ;; \
-        armv6l)   BINARY="ttyd.arm" ;; \
-        i686)     BINARY="ttyd.i686" ;; \
-        *)        echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    x86_64)   BINARY="ttyd.x86_64" ;; \
+    aarch64)  BINARY="ttyd.aarch64" ;; \
+    armv7l)   BINARY="ttyd.armhf" ;; \
+    armv6l)   BINARY="ttyd.arm" ;; \
+    i686)     BINARY="ttyd.i686" ;; \
+    *)        echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
     esac; \
     curl -L "https://github.com/tsl0922/ttyd/releases/download/1.7.7/${BINARY}" -o /usr/local/bin/ttyd; \
     chmod +x /usr/local/bin/ttyd
@@ -91,7 +88,7 @@ RUN pip3 install --no-cache-dir --break-system-packages \
 
 # Testing
 RUN pip3 install --no-cache-dir --break-system-packages \
-     pytest pytest-cov tox
+    pytest pytest-cov tox
 
 # Rich output & CLI toys
 RUN pip3 install --no-cache-dir --break-system-packages \
@@ -105,17 +102,17 @@ WORKDIR /home/devuser/app
 RUN chown devuser:devuser /home/devuser/app
 
 RUN mkdir -p \
-        /var/log \
-        /var/lib/vector \
-        /var/log/vector \
-        /var/run \
-        /home/devuser/run && \
+    /var/log \
+    /var/lib/vector \
+    /var/log/vector \
+    /var/run \
+    /home/devuser/run && \
     chown -R devuser:devuser \
-        /var/log \
-        /var/lib/vector \
-        /var/log/vector \
-        /var/run \
-        /home/devuser/run
+    /var/log \
+    /var/lib/vector \
+    /var/log/vector \
+    /var/run \
+    /home/devuser/run
 
 # Vector config
 COPY --chown=devuser:devuser vector.toml /etc/vector/vector.toml

--- a/stacks/python/trixie/Dockerfile
+++ b/stacks/python/trixie/Dockerfile
@@ -2,8 +2,7 @@
 
 FROM debian:trixie-slim
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    TERM=xterm \
+ENV TERM=xterm \
     LOG_USER_ID=devuser \
     LOG_WORKSPACE_ID=default \
     LOG_SESSION_ID=dev-session
@@ -38,12 +37,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN set -eux; \
     ARCH=$(uname -m); \
     case "$ARCH" in \
-        x86_64)   BINARY="ttyd.x86_64" ;; \
-        aarch64)  BINARY="ttyd.aarch64" ;; \
-        armv7l)   BINARY="ttyd.armhf" ;; \
-        armv6l)   BINARY="ttyd.arm" ;; \
-        i686)     BINARY="ttyd.i686" ;; \
-        *)        echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
+    x86_64)   BINARY="ttyd.x86_64" ;; \
+    aarch64)  BINARY="ttyd.aarch64" ;; \
+    armv7l)   BINARY="ttyd.armhf" ;; \
+    armv6l)   BINARY="ttyd.arm" ;; \
+    i686)     BINARY="ttyd.i686" ;; \
+    *)        echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
     esac; \
     curl -L "https://github.com/tsl0922/ttyd/releases/download/1.7.7/${BINARY}" -o /usr/local/bin/ttyd; \
     chmod +x /usr/local/bin/ttyd
@@ -93,17 +92,17 @@ WORKDIR /home/devuser/app
 RUN chown devuser:devuser /home/devuser/app
 
 RUN mkdir -p \
-        /var/log \
-        /var/lib/vector \
-        /var/log/vector \
-        /var/run \
-        /home/devuser/run && \
+    /var/log \
+    /var/lib/vector \
+    /var/log/vector \
+    /var/run \
+    /home/devuser/run && \
     chown -R devuser:devuser \
-        /var/log \
-        /var/lib/vector \
-        /var/log/vector \
-        /var/run \
-        /home/devuser/run
+    /var/log \
+    /var/lib/vector \
+    /var/log/vector \
+    /var/run \
+    /home/devuser/run
 
 # Vector config
 COPY --chown=devuser:devuser vector.toml /etc/vector/vector.toml

--- a/stacks/stacks.json
+++ b/stacks/stacks.json
@@ -87,6 +87,20 @@
         ]
     },
     {
+        "name": "CBQN",
+        "tags": [
+            {
+                "id": "cbqn:bookworm",
+                "base": "debian:bookworm-slim",
+                "name": "CBQN on Debian Bookworm",
+                "platforms": [
+                    "linux/amd64",
+                    "linux/arm64"
+                ]
+            }
+        ]
+    },
+    {
         "name": ".NET",
         "tags": [
             {
@@ -137,20 +151,6 @@
                 "id": "gambit-scheme:trixie",
                 "base": "debian:trixie-slim",
                 "name": "Gambit Schemes on Debian Trixie",
-                "platforms": [
-                    "linux/amd64",
-                    "linux/arm64"
-                ]
-            }
-        ]
-    },
-    {
-        "name": "CBQN",
-        "tags": [
-            {
-                "id": "cbqn:bookworm",
-                "base": "debian:bookworm-slim",
-                "name": "CBQN on Debian Bookworm",
                 "platforms": [
                     "linux/amd64",
                     "linux/arm64"

--- a/stacks/stacks.json
+++ b/stacks/stacks.json
@@ -145,6 +145,20 @@
         ]
     },
     {
+        "name": "CBQN",
+        "tags": [
+            {
+                "id": "cbqn:bookworm",
+                "base": "debian:bookworm-slim",
+                "name": "CBQN on Debian Bookworm",
+                "platforms": [
+                    "linux/amd64",
+                    "linux/arm64"
+                ]
+            }
+        ]
+    },
+    {
         "name": "GNU COBOL",
         "tags": [
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the CBQN programming language stack, including a new container image based on Debian Bookworm.
  - CBQN stack is now listed among supported stacks, with multi-architecture support for both amd64 and arm64 platforms.

- **Documentation**
  - Updated documentation to include CBQN stack details and build instructions.

- **Style**
  - Improved formatting and indentation for several Dockerfiles to enhance readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->